### PR TITLE
Fixes the Statify Method (and Templating)

### DIFF
--- a/fictive/print_helper.py
+++ b/fictive/print_helper.py
@@ -1,21 +1,59 @@
 import re
 from .states import Statebag
+from dataclasses import dataclass
 
-LABEL = re.compile(r"\{(.+?)\}")
+
+@dataclass
+class TemplateMatch:
+    """
+    Helper class for scanning for template strings.
+    """
+    start: int  # the start of the match
+    end: int  # the end of the match
+    key: str  # the key value inside the "{}"s
+
+
+def scan_for_template(text: str) -> TemplateMatch | None:
+    """
+    Scan through a string for template entries. Supports escaping with \\.
+    """
+    escaped: bool = False
+    templateStarted = False
+    templateStartIdx: int = 0
+    for i, c in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if c == "\\":
+            escaped = True
+        if c == "{" and not templateStarted:
+            templateStarted = True
+            templateStartIdx = i
+        elif c == "}" and templateStarted:
+            return TemplateMatch(
+                templateStartIdx,
+                i+1,
+                text[templateStartIdx+1:i]
+            )
+    return None
 
 
 def statify(text: str, statebag: Statebag):
     """
     Handles templating inside of state strings.
 
-    Any `{someKey}` will be replaced by `someKey` from the statebag. If `somekey` 
+    Any `{someKey}` will be replaced by `someKey` from the statebag. If `somekey`
     does not exist, an error will be printed out instead.
     """
-    match = LABEL.search(text)
+    match = scan_for_template(text)
+    result = text  # our final output
+    working = text  # our working copy that we truncate as we work
     while (match):
-        to_replace = text[match.span()[0]:match.span()[1]]
+        to_replace = working[match.start: match.end]
         replace_with = statebag.get(
-            match.groups()[0], f"<<ERROR: {to_replace[1:-1]} not in state bag>>")
-        text = text.replace(to_replace, str(replace_with))
-        match = LABEL.search(text)
-    return text
+            match.key, f"<<ERROR: {match.key} not in state bag>>")
+        # only replace one at a time, so our result and our working don't get out of sync
+        result = result.replace(to_replace, str(replace_with), 1)
+        working = working[match.end:]
+        match = scan_for_template(working)
+    return result


### PR DESCRIPTION
The "statify" method, which injects statebag data into our output text, based on the existence of "{}" wrappers throws away its regex parsing and replaces it with a scanner. The advantage of the scanner is that:

* Protects against player injection
	* Previously, if the player entered "{someText}" as a matcher input, it would be handled as a template.
	* Or worse, it could create an endless loop, locking up the game
* Allows Escape Characters
	* You can now use "\{This won't be processed as a template\}"